### PR TITLE
fix: avoid loading comments when marking as done

### DIFF
--- a/src/components/notifications/notification.tsx
+++ b/src/components/notifications/notification.tsx
@@ -43,6 +43,13 @@ const NotificationItemComponent = React.forwardRef<HTMLDivElement, NotificationI
       setLoading(false);
     };
 
+    const markAsDone = (event: React.MouseEvent | React.KeyboardEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+      setLoading(true);
+      onCheck();
+    };
+
     const onKeyDown = (event: React.KeyboardEvent) => {
       // eslint-disable-next-line default-case
       switch (event.key) {
@@ -50,10 +57,7 @@ const NotificationItemComponent = React.forwardRef<HTMLDivElement, NotificationI
           setOpen(false);
           break;
         case 'e':
-          event.preventDefault();
-          event.stopPropagation();
-          setLoading(true);
-          onCheck();
+          markAsDone(event);
           break;
         case 'o':
           window.open(issue.html_url);
@@ -111,7 +115,7 @@ const NotificationItemComponent = React.forwardRef<HTMLDivElement, NotificationI
             {notification.repository.owner.login}/{notification.repository.name}
           </span>
           <EuiAvatar type="space" imageUrl={issue.user.avatar_url} name={issue.user.login} size="s" className={css.notification__author} />
-          <EuiButtonIcon iconType="check" aria-label="Done" onClick={() => onCheck()} />
+          <EuiButtonIcon iconType="check" aria-label="Done" onClick={markAsDone} />
           <EuiButtonIcon
             iconType="popout"
             aria-label="Open on GitHub"


### PR DESCRIPTION
This will stop the event propagation when clicking on the check button and will avoid the loading of the content caused by the onClick of the parent