### PR TITLE
feat: choose repo list from URL

### DIFF
--- a/src/components/dashboard/dashboard.tsx
+++ b/src/components/dashboard/dashboard.tsx
@@ -1,18 +1,20 @@
 import React, { useState } from 'react';
-
+import { Location } from 'history';
 import { Sidebar } from './sidebar';
 import { NotificationList } from '../notifications';
+import { getReposFromLocationSearch } from '../../services/github'
 
 import css from './dashboard.module.scss';
 
-export function Dashboard() {
+export function Dashboard({ location }: {location: Location}) {
   const [notificationCount, setNotificationCount] = useState<number | undefined>(undefined);
+  const repos = getReposFromLocationSearch(location.search);
 
   return (
     <div className={css.dashboard}>
       <Sidebar className={css.dashboard__sidebar} inboxTotal={notificationCount}/>
       <main className={css.dashboard__main}>
-        <NotificationList onNotificationsChange={(nots) => setNotificationCount(nots.length)}/>
+        <NotificationList onNotificationsChange={(nots) => setNotificationCount(nots.length)} repos={repos}/>
       </main>
     </div>
   );

--- a/src/components/notifications/notification-list.tsx
+++ b/src/components/notifications/notification-list.tsx
@@ -1,4 +1,5 @@
 import { EuiEmptyPrompt, EuiLoadingSpinner } from '@elastic/eui';
+import Octokit from '@octokit/rest';
 import moment from 'moment';
 import React, { useEffect, useState } from 'react';
 import { useGitHub, useSetting } from '../../services';
@@ -6,6 +7,7 @@ import { Notification as NotificationType } from '../../types';
 import { NotificationItem } from './notification';
 
 interface NotificationListProps {
+  repos?: Octokit.ActivityListNotificationsForRepoParams[],
   onNotificationsChange: (nots: NotificationType[]) => void;
 }
 
@@ -24,7 +26,7 @@ export function NotificationList(props: NotificationListProps) {
   }
 
   const loadNots = async () => {
-    const nots = await github.getUnreadNotifications();
+    const nots = await github.getUnreadNotifications(props.repos);
     // TODO: This should be extracted to a better place
     if (isWebNotificationsActive) {
       const newNotifications: NotificationType[] = [];


### PR DESCRIPTION
Allow select a subset of repos via URL query string: `?repos=`

The list of repo is a string of repo name separated by `,` like:
```
?repos=kibana/elastic-charts,markov00/jsooner,facebook/react
```

